### PR TITLE
Reload the page in HTTPS if it is visited using HTTP.

### DIFF
--- a/test/client.html
+++ b/test/client.html
@@ -241,6 +241,9 @@
   <script src="js/mic-button.js"></script>
   <script src="js/client.js"></script>
   <script>
+      if (window.location.protocol === 'http:') {
+          window.location = 'https:' + window.location.href.substring(window.location.protocol.length);
+      }
       var help;
       var lastQuery;
       var currentRating = 5;


### PR DESCRIPTION
Most browsers refuse access to the microphone if a page is not loaded through HTTPS.  This change is to reload the page in HTTPS when people accidentally visit it from HTTP.