### PR TITLE
Updates to use the new API.

### DIFF
--- a/test/client.html
+++ b/test/client.html
@@ -342,11 +342,15 @@
               voysisClient.warn('Listening...');
               var voysisSession = voysisClient.getVoysisSession();
               var audioContext = voysisClient.getAudioContext();
-              voysisSession.sendAudioQuery('en-us', voysisClient.getPreviousQueryContext(), audioContext).then(function (results) {
+              voysisSession.sendAudioQuery('en-US', voysisClient.getPreviousQueryContext(), voysisClient.getQueryConversationId(), audioContext).then(function (results) {
                   lastQuery = results[0];
                   var queryResults = results[1];
+                  console.log("Query Results: ", queryResults);
                   if (queryResults.context) {
                       voysisClient.setPreviousQueryContext(queryResults.context);
+                  }
+                  if(queryResults.conversationId) {
+                      voysisClient.setQueryConversationId(queryResults.conversationId);
                   }
                   mic_button.classList.remove('is-active');
                   voysisClient.finished('Query complete.');

--- a/test/index.html
+++ b/test/index.html
@@ -16,7 +16,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text">Hostname</span>
                             </div>
-                            <input type="url" class="form-control" id="hostname" onchange="updateHost()">
+                            <input type="url" class="form-control" id="hostname" onchange="updateHost(this.value)">
                         </div>
                     </div>
                     <div class="col col-12 col-md-6">
@@ -24,7 +24,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text">Refresh Token</span>
                             </div>
-                            <input type="text" class="form-control" id="refreshToken" onchange="updateRefreshToken()">
+                            <input type="text" class="form-control" id="refreshToken" onchange="updateRefreshToken(this.value)">
                         </div>
                     </div>
                 </div>
@@ -85,7 +85,7 @@
             }
             function startStreaming() {
                 console.log('Using JS library version: ', VoysisSession.version);
-                voysisClient.getVoysisSession().sendAudioQuery('en-us', voysisClient.getPreviousQueryContext()).then(function (result) {
+                voysisClient.getVoysisSession().sendAudioQuery('en-US', voysisClient.getPreviousQueryContext()).then(function (result) {
                     var queryResult = result[1];
                     if (queryResult.context) {
                         voysisClient.setPreviousQueryContext(queryResult.context);
@@ -100,10 +100,10 @@
                 });
             }
             function updateHost(host) {
-                voysisClient.setHost(document.getElementById('hostname').value);
+                voysisClient.setHost(host);
             }
             function updateRefreshToken(refreshToken) {
-                voysisClient.setRefreshToken(document.getElementById('refreshToken').value);
+                voysisClient.setRefreshToken(refreshToken);
             }
             document.getElementById('hostname').value = voysisClient.getHost();
             document.getElementById('refreshToken').value = voysisClient.getRefreshToken();

--- a/test/js/client.js
+++ b/test/js/client.js
@@ -38,6 +38,7 @@
         var statusMessageElement_;
         var statusBarElement_;
         var previousQueryContext_;
+        var queryConversationId_;
         var sessionChanged_ = false;
 
         function createUuid() {
@@ -81,12 +82,20 @@
                 sessionChanged_ = true;
             },
 
-            getPreviousQueryContext: function() {
+            getPreviousQueryContext: function () {
                 return previousQueryContext_;
             },
 
-            setPreviousQueryContext: function(context) {
+            setPreviousQueryContext: function (context) {
                 previousQueryContext_ = context;
+            },
+
+            getQueryConversationId: function () {
+                return queryConversationId_;
+            },
+
+            setQueryConversationId: function (conversationId) {
+                queryConversationId_ = conversationId;
             },
 
             getRefreshToken: function () {


### PR DESCRIPTION
Remove methods for conversations, which are now no longer their own REST entity.
'conversationId' can be passed in when creating a new audio query.
'language' is renamed 'locale' and send in the entity information instead of a header.