### PR TITLE
Add a simple grunt build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,11 +2,11 @@
 /.idea
 **/*.iml
 
+# Ignore NPM installed dependencies
+/node_modules
+
 # Ignore the project build directory
 /build
-
-# Ignore the buildshim build directory
-/_builds
 
 # Compiled source #
 ###################

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,46 @@
+module.exports = function (grunt) {
+
+    var pkg = grunt.file.readJSON('package.json');
+    grunt.initConfig({
+        pkg: grunt.file.readJSON('package.json'),
+        copy: {
+            main: {
+                options: {
+                    process: function (content, srcpath) {
+                        return content.replace(/\${LIBRARY_VERSION}/g, pkg.version);
+                    }
+                },
+                files: [
+                    {
+                        nonull: true,
+                        src: 'src/js/voysis.js',
+                        dest: 'build/voysis.js',
+                    },
+                    {
+                        nonull: true,
+                        src: 'src/js/voysis.js',
+                        dest: 'build/voysis-<%= pkg.version %>.js',
+                    }
+                ]
+            }
+        },
+        uglify: {
+            options: {
+                banner: '/* Copyright (c) <%= grunt.template.today("yyyy") %> Voysis | Released under the MIT License */\n'
+            },
+            main: {
+                files: {
+                    'build/voysis.min.js': 'build/voysis.js',
+                    'build/voysis-<%= pkg.version %>.min.js': 'build/voysis.js'
+                }
+            }
+        }
+    });
+
+    grunt.loadNpmTasks('grunt-contrib-uglify-es');
+    grunt.loadNpmTasks('grunt-contrib-copy');
+
+    grunt.registerTask('dist', ['copy', 'uglify']);
+    grunt.registerTask('default', ['dist']);
+
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "voysis-js",
+  "version": "1.0.8",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/voysis/voysis-js"
+  },
+  "devDependencies": {
+    "grunt": "^1.0.2",
+    "grunt-contrib-copy": "^1.0.0",
+    "grunt-contrib-uglify-es": "^3.3.0"
+  }
+}


### PR DESCRIPTION
Add a grunt build, which replaces the ${LIBRARY_VERSION} placeholder text and uglifies the JS files.

This is also a pre-cursor to tests being run through the grunt build.