### PR TITLE
Add in linting and an example jasmine unit test.  

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,13 @@
+{
+  "extends": "eslint:recommended",
+  "parserOptions": {
+    "ecmaVersion": 2017
+  },
+  "env": {
+    "amd": true,
+    "browser": true,
+    "es6": true,
+    "jasmine": true,
+    "node": true
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 /.idea
 **/*.iml
 
+# Ignore downloaded grunt plugins
+/.grunt
+
 # Ignore NPM installed dependencies
 /node_modules
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,12 +1,29 @@
 module.exports = function (grunt) {
+    'use strict';
 
     var pkg = grunt.file.readJSON('package.json');
     grunt.initConfig({
         pkg: grunt.file.readJSON('package.json'),
+        eslint: {
+            all: [
+                'Gruntfile.js',
+                'src/js/*.js'
+            ],
+            options: {
+                configFile: '.eslintrc'
+            }
+        },
+        jasmine: {
+            src: 'src/js/*.js',
+            options: {
+                specs: 'spec/*.js',
+                keepRunner: false
+            }
+        },
         copy: {
             main: {
                 options: {
-                    process: function (content, srcpath) {
+                    process: function (content) {
                         return content.replace(/\${LIBRARY_VERSION}/g, pkg.version);
                     }
                 },
@@ -37,10 +54,13 @@ module.exports = function (grunt) {
         }
     });
 
-    grunt.loadNpmTasks('grunt-contrib-uglify-es');
     grunt.loadNpmTasks('grunt-contrib-copy');
+    grunt.loadNpmTasks('grunt-contrib-jasmine');
+    grunt.loadNpmTasks('grunt-contrib-uglify-es');
+    grunt.loadNpmTasks('grunt-eslint');
 
+    grunt.registerTask('test', ['jasmine']);
     grunt.registerTask('dist', ['copy', 'uglify']);
-    grunt.registerTask('default', ['dist']);
+    grunt.registerTask('default', ['test', 'eslint', 'dist']);
 
 };

--- a/README.md
+++ b/README.md
@@ -6,6 +6,22 @@ This is a javascript library that facilitates sending voice
 queries to a Voysis instance. The client allows audio to be
 streamed from the device microphone.
 
+Build & Test
+------------
+_If you haven't used [grunt](https://gruntjs.com/) before, be sure to check out the [Getting Started](https://gruntjs.com/getting-started) guide._
+
+Assuming you have grunt installed, install the project's dependencies
+
+```bash
+npm install
+```
+
+Once that's done, you can run the unit tests via `grunt test` or `npm test`
+
+Creating the files for distribution can be done by `grunt dist`
+
+Running `grunt` will run the default tasks, which will test and lint the code, and build the distribution.
+
 Documentation
 -------------
 
@@ -16,19 +32,23 @@ Basic Usage
 
 The first step to using the lib is to create a VoysisSession.
 
+```js
     var voysisSession = new VoysisSession({
         host: 'mycompany.voysis.io',
         audioProfile: 'f8338e44-9d48-11e7-abc4-cec278b6b50a'
     });
+```
 
 From here, the simplest usage is to call sendAudioQuery, which
 takes the language which will be used as a parameter.
 
+```js
     voysisSession.sendAudioQuery('en-US').then(function (queryResult) {
         console.log('You said: ' + queryResult.textQuery.text);
     }).catch(function (error) {
         console.log("ERROR: ", error.message);
     });
+```
 
 The object passed to the callback will be the result of the query.
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,11 @@
   "devDependencies": {
     "grunt": "^1.0.2",
     "grunt-contrib-copy": "^1.0.0",
-    "grunt-contrib-uglify-es": "^3.3.0"
+    "grunt-contrib-jasmine": "^1.2.0",
+    "grunt-contrib-uglify-es": "^3.3.0",
+    "grunt-eslint": "^20.1.0"
+  },
+  "scripts": {
+    "test": "grunt test"
   }
 }

--- a/spec/voysis.spec.js
+++ b/spec/voysis.spec.js
@@ -1,0 +1,8 @@
+'use strict';
+
+describe("Test static pieces of information", function () {
+
+    it("Version number exists", function () {
+        expect(VoysisSession.version).toBe("${LIBRARY_VERSION}");
+    });
+});

--- a/src/js/voysis.js
+++ b/src/js/voysis.js
@@ -31,13 +31,13 @@
     }
 })(this, function () {
     'use strict';
-    const DESIRED_SAMPLING_RATE = 16000;
-    const STREAM_AUDIO_CALLBACK_KEY = 'AudioStreamCallback';
-    const VAD_STOP_CALLBACK_KEY = 'VadStopCallback';
-    const ERROR_CALLBACK_KEY_POSTFIX = '.error';
-    const VAD_STOP_NOTIFICATION = 'vad_stop';
-    const QUERY_COMPLETE_NOTIFICATION = 'query_complete';
-    const INTERNAL_SERVER_ERROR_NOTIFICATION = 'internal_server_error';
+    var DESIRED_SAMPLING_RATE = 16000;
+    var STREAM_AUDIO_CALLBACK_KEY = 'AudioStreamCallback';
+    var VAD_STOP_CALLBACK_KEY = 'VadStopCallback';
+    var ERROR_CALLBACK_KEY_POSTFIX = '.error';
+    var VAD_STOP_NOTIFICATION = 'vad_stop';
+    var QUERY_COMPLETE_NOTIFICATION = 'query_complete';
+    var INTERNAL_SERVER_ERROR_NOTIFICATION = 'internal_server_error';
     var AudioContext = window.AudioContext || window.webkitAudioContext;
     var audioContext_ = null;
     var args_ = {};
@@ -77,7 +77,7 @@
         // Look for a getUserMedia method for the current platform
         if (AudioContext &&
             (navigator.getUserMedia || navigator.webkitGetUserMedia || navigator.mozGetUserMedia ||
-            (navigator.mediaDevices && navigator.mediaDevices.getUserMedia))) {
+                (navigator.mediaDevices && navigator.mediaDevices.getUserMedia))) {
             return true;
         }
         return false;
@@ -193,22 +193,22 @@
         debug('Durations', queryDurations_);
         sendFeedback(query, null, null, queryDurations_);
         return query;
-    };
+    }
 
     function sendFeedback(queryForFeedback, rating, description, durations) {
-        var sendFeedbackFunction = function (sessionApiToken) {
+        var sendFeedbackFunction = function () {
             var feedbackUri = queryForFeedback._links.self.href + '/feedback';
             debug('Sending feedback to: ', feedbackUri);
             var feedbackData = {};
             if (rating) {
-                feedbackData['rating'] = rating;
+                feedbackData.rating = rating;
             }
             if (description) {
-                feedbackData['description'] = description;
+                feedbackData.description = description;
             }
             if (durations) {
                 // JSON doesn't support Map, so we need to convert it to an Object
-                feedbackData['durations'] = mapToObject(durations);
+                feedbackData.durations = mapToObject(durations);
             }
             var jsonFeedbackData = JSON.stringify(feedbackData);
             debug("Sending feedback: ", jsonFeedbackData);
@@ -348,13 +348,13 @@
     }
 
     function sendAudioRequest(method, uri, entity, skipCheckSessionToken) {
-        var sendRequestFunction = function (sessionApiToken) {
+        var sendRequestFunction = function () {
             var audioHeaders = {
                 'X-Voysis-Audio-Profile-Id': args_.audioProfileId,
                 'X-Voysis-Ignore-Vad': false,
                 'Accept': 'application/vnd.voysisquery.v1+json'
             };
-            return sendRequest(method, uri, entity, audioHeaders, sessionApiToken_.token)
+            return sendRequest(method, uri, entity, audioHeaders, sessionApiToken_.token);
         };
         if (skipCheckSessionToken) {
             return sendRequestFunction(sessionApiToken_);
@@ -399,7 +399,7 @@
                     'headers': {}
                 };
                 if (authToken) {
-                    msg.headers.Authorization = 'Bearer ' + authToken
+                    msg.headers.Authorization = 'Bearer ' + authToken;
                 }
                 if (entity != null) {
                     msg.entity = entity;
@@ -435,7 +435,7 @@
 
     function checkFunction(func) {
         if (func && typeof func !== 'function') {
-            throw new TypeError('Not a function')
+            throw new TypeError('Not a function');
         }
         return (func != null);
     }
@@ -494,6 +494,7 @@
 
     function debug() {
         if (args_.debugEnabled) {
+            /*eslint no-console: ["error", { allow: ["log"] }] */
             console.log.apply(console, arguments);
         }
     }


### PR DESCRIPTION
Made `voysis.js` ES5 syntax compliant by changing the `const` keywords to `var` - this allows the Jasmine tests to be run in a wider variety of runtimes (PhantomJS / Headless Chrome / Real Browser etc.).

Fixed some lint issues in `voysis.js`