### PR TITLE
Updates to allow Chrome to run on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,10 @@ sudo: required
 language: node_js
 node_js:
   - "8"
-addons:
-  chrome: stable
 cache:
   directories:
     - "node_modules"
+before_script:
+  - npm install -g grunt-cli
+script:
+  - grunt test eslint

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,9 @@
+sudo: required
 language: node_js
 node_js:
   - "8"
+addons:
+  chrome: stable
+cache:
+  directories:
+    - "node_modules"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Voysis Javascript SDK
 =====================
-![Build Status: Linux](https://travis-ci.org/voysis/voysis-js.svg?branch=master)
+[![Build Status](https://travis-ci.org/voysis/voysis-js.svg)](https://travis-ci.org/voysis/voysis-js)
 
 This document provides a brief overview of the voysis javascript sdk.
 This is a javascript library that facilitates sending voice


### PR DESCRIPTION
There is an issue with running headless Chrome on travis (See https://github.com/travis-ci/travis-ci/issues/8836) - The workaround is to run the build container with `sudo` enabled.

Also, build using a specific `grunt` command so that `eslint` is run as part of the build.