### PR TITLE
Improve the speed of the interpolateArray() function.

### DIFF
--- a/src/js/voysis.js
+++ b/src/js/voysis.js
@@ -488,8 +488,8 @@
         newData[0] = data[0]; // for new allocation
         for (var i = 1; i < fitCount - 1; i++) {
             var tmp = i * springFactor;
-            var before = Number(Math.floor(tmp)).toFixed();
-            var after = Number(Math.ceil(tmp)).toFixed();
+            var before = ~~tmp; // Faster than Math.floor() on most mobile devices
+            var after = Math.ceil(tmp);
             var atPoint = tmp - before;
             newData[i] = linearInterpolate(data[before], data[after], atPoint);
         }


### PR DESCRIPTION
I've tested that the function outputs exactly the same values as the old method.

In testing, the new `interpolateArray()` method is over 50 times faster (according to the Chrome performance monitor).

The new version if available for testing at:
https://s3.amazonaws.com/voysis-scratch/jfarrelly/test/client.html

The code used for the performance test (and output comparison) is at:
https://s3.amazonaws.com/voysis-scratch/jfarrelly/test/foo.html