### PR TITLE
Make this version number the same as the most recent git tag.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "voysis-js",
-  "version": "1.0.8",
+  "version": "1.1.0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
When doing releases, the 'npm version' command should be used, as this updated the version property, and also creates a matching git tag.