### PR TITLE
Don't sent any more audio after we have received the request to stop streaming.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "voysis-js",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
It's possible (even though forbidden in the spec) that `onaudioprocess` can be called even after we disconnect the audio processing pipeline.  This means that in the old code, it was possible we could continue to send audio data after we had sent an end stream message.

This diff is easier to view if you ignore whitespace.