### PR TITLE
Only send the length of PCM data in the buffer on audio processing event, not the whole buffer.

### DIFF
--- a/src/js/voysis.js
+++ b/src/js/voysis.js
@@ -154,7 +154,7 @@
                                 var inBuf = audioProcessingEvent.inputBuffer;
                                 if (inBuf.length > 0) {
                                     var audioDataArray = new Float32Array(
-                                            inBuf.getChannelData(0)
+                                        inBuf.getChannelData(0)
                                     );
                                     webSocket_.send(audioDataArray.buffer);
                                 }

--- a/src/js/voysis.js
+++ b/src/js/voysis.js
@@ -152,9 +152,11 @@
                                     recordingCallbackSent = true;
                                 }
                                 var inBuf = audioProcessingEvent.inputBuffer;
-                                var audioDataArray = new Float32Array(inBuf.length);
-                                inBuf.copyFromChannel(audioDataArray, 0);
-                                webSocket_.send(audioDataArray.buffer);
+                                if (inBuf.length > 0) {
+                                    var audioDataArray = new Float32Array(inBuf.length);
+                                    inBuf.copyFromChannel(audioDataArray, 0);
+                                    webSocket_.send(audioDataArray.buffer);
+                                }
                                 if (stopStreaming_) {
                                     debug('Stopping streaming...');
                                     var byteArray = new Int8Array(1);

--- a/src/js/voysis.js
+++ b/src/js/voysis.js
@@ -153,8 +153,9 @@
                                 }
                                 var inBuf = audioProcessingEvent.inputBuffer;
                                 if (inBuf.length > 0) {
-                                    var audioDataArray = new Float32Array(inBuf.length);
-                                    inBuf.copyFromChannel(audioDataArray, 0);
+                                    var audioDataArray = new Float32Array(
+                                            inBuf.getChannelData(0)
+                                    );
                                     webSocket_.send(audioDataArray.buffer);
                                 }
                                 if (stopStreaming_) {

--- a/src/js/voysis.js
+++ b/src/js/voysis.js
@@ -151,7 +151,9 @@
                                     callFunction(callback, 'recording_started');
                                     recordingCallbackSent = true;
                                 }
-                                var audioDataArray = audioProcessingEvent.inputBuffer.getChannelData(0);
+                                var inBuf = audioProcessingEvent.inputBuffer;
+                                var audioDataArray = new Float32Array(inBuf.length);
+                                inBuf.copyFromChannel(audioDataArray, 0);
                                 webSocket_.send(audioDataArray.buffer);
                                 if (stopStreaming_) {
                                     debug('Stopping streaming...');


### PR DESCRIPTION
Previous impl was sending the entire buffer even though it might not have been filled. The `audioProcessingEvent.inputBuffer.length` field indicates how much PCM data is in the buffer.

This change also copies the data out of the buffer into a float array before trying to send it on the websocket. This ensures that the data in the buffer isn't overwritten while we are sending it on the websocket.